### PR TITLE
dnsmasq coexistence

### DIFF
--- a/conf/dnsmasq.conf
+++ b/conf/dnsmasq.conf
@@ -1,0 +1,2 @@
+listen-address=127.0.0.1
+bind-interfaces

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -13,6 +13,8 @@ RestartSec=10
 KillSignal=SIGINT
 SyslogIdentifier=dns-server
 Environment=DNS_SERVER_LOG_FOLDER_PATH=/var/log/__APP__/dns
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target

--- a/doc/PRE_UPGRADE.d/15.2.0~ynh1.md
+++ b/doc/PRE_UPGRADE.d/15.2.0~ynh1.md
@@ -1,0 +1,1 @@
+After upgrading, you must add your ynh server's local IP address(es) to `DNS Server Local End Points`: https://__DOMAIN__/#settingsTabPaneGeneral and then restart __APP__.

--- a/scripts/install
+++ b/scripts/install
@@ -26,7 +26,13 @@ ynh_config_add_systemd
 mkdir -p "/var/log/$app/dns"
 chown -R "$app:$app" "/var/log/$app"
 
+ynh_hide_warnings yunohost firewall allow Both 53
+
 yunohost service add "$app" --description="Technitium DNS Server" --log="/var/log/$app/$app.log" --needs_exposed_ports="53"
+
+ynh_config_add --template="dnsmasq.conf" --destination="/etc/dnsmasq.d/$app.conf"
+
+ynh_systemctl --service="dnsmasq" --action="restart"
 
 #=================================================
 # ADD A CRON JOB
@@ -37,14 +43,41 @@ chmod 644 "/etc/cron.d/$app"
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================
-ynh_script_progression "Starting $app's systemd service..."
-
-ynh_systemctl --service="$app" --action="restart" --log_path=systemd --wait_until="was started successfully"
+ynh_systemctl --service="$app" --action="start" --log_path=systemd --wait_until="was started successfully"
 
 #=================================================
 # LINK LOGS
 #=================================================
 ln -sf $(ls -t /var/log/$app/dns/*.log | head -n 1) /var/log/$app/$app.log
+
+#=================================================
+# SET LOCAL ENDPOINT IP(S)
+#=================================================
+gateway_v4=$(ip -4 route show default | awk '{print $3}' | head -n1)
+ipv4=$(ip -4 route get "$gateway_v4" 2>/dev/null | grep -oP 'src \K\S+')
+
+gateway_v6=$(ip -6 route show default | awk '{print $3}' | head -n1)
+if [ -n "$gateway_v6" ]; then
+    ipv6=$(ip -6 route get "$gateway_v6" 2>/dev/null | grep -oP 'src \K\S+' | grep -v '^fe80')
+else
+    ipv6=""
+fi
+
+if [ -n "$ipv6" ]; then
+    endpoints="$ipv4:53,[$ipv6]:53"
+else
+    endpoints="$ipv4:53"
+fi
+
+mytoken1=$(curl -s "http://127.0.0.1:5380/api/user/createToken?user=admin&pass=admin&tokenName=mytoken1" | jq -r '.token')
+curl -s "http://localhost:5380/api/settings/set?dnsServerLocalEndPoints=$endpoints&Token=$mytoken1"
+
+#=================================================
+# RESTART SYSTEMD SERVICE
+#=================================================
+ynh_script_progression "Starting $app's systemd service..."
+
+ynh_systemctl --service="$app" --action="restart" --log_path=systemd --wait_until="was started successfully"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -58,7 +58,7 @@ ipv4=$(ip -4 route get "$gateway_v4" 2>/dev/null | grep -oP 'src \K\S+')
 
 gateway_v6=$(ip -6 route show default | awk '{print $3}' | head -n1)
 if [ -n "$gateway_v6" ]; then
-    ipv6=$(ip -6 route get "$gateway_v6" 2>/dev/null | grep -oP 'src \K\S+' | grep -v '^fe80')
+    ipv6=$(ip -6 route get "$gateway_v6" 2>/dev/null | grep -oP 'src \K\S+' | grep -v '^fe80' || true)
 else
     ipv6=""
 fi

--- a/scripts/remove
+++ b/scripts/remove
@@ -16,6 +16,8 @@ if ynh_hide_warnings yunohost service status "$app" >/dev/null; then
     yunohost service remove "$app"
 fi
 
+ynh_hide_warnings yunohost firewall disallow Both 53
+
 ynh_config_remove_systemd
 
 ynh_config_remove_nginx
@@ -23,6 +25,8 @@ ynh_config_remove_nginx
 ynh_safe_rm "/var/log/$app"
 
 ynh_safe_rm "/etc/cron.d/$app"
+
+ynh_safe_rm "/etc/dnsmasq.d/$app.conf"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/remove
+++ b/scripts/remove
@@ -22,8 +22,6 @@ ynh_config_remove_systemd
 
 ynh_config_remove_nginx
 
-ynh_safe_rm "/var/log/$app"
-
 ynh_safe_rm "/etc/cron.d/$app"
 
 ynh_safe_rm "/etc/dnsmasq.d/$app.conf"

--- a/scripts/restore
+++ b/scripts/restore
@@ -29,14 +29,21 @@ ynh_restore "/etc/nginx/conf.d/$domain.d/$app.conf"
 
 ynh_restore "/var/log/$app"
 
+ynh_hide_warnings yunohost firewall allow Both 53
+
 ynh_restore "/etc/systemd/system/$app.service"
 systemctl enable "$app.service" --quiet
 yunohost service add "$app" --description="Technitium DNS Server" --log="/var/log/$app/$app.log" --needs_exposed_ports=53
+
+ynh_config_add --template="dnsmasq.conf" --destination="/etc/dnsmasq.d/$app.conf"
+
+ynh_systemctl --service="dnsmasq" --action="restart"
 
 #=================================================
 # ADD A CRON JOB
 #=================================================
 ynh_config_add --template="logsymlink.cron" --destination="/etc/cron.d/$app"
+chown root: "/etc/cron.d/$app"
 chmod 644 "/etc/cron.d/$app"
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -30,6 +30,9 @@ if ynh_app_upgrading_from_version_before_or_equal_to 14.3.0~ynh1; then
     chown -R "$app:$app" "/var/log/$app"
     ln -sf "/var/log/$app/dns" "$data_dir/logs"
     ln -sf $(ls -t /var/log/$app/dns/*.log | head -n 1) /var/log/$app/$app.log
+    ynh_config_add --template="dnsmasq.conf" --destination="/etc/dnsmasq.d/$app.conf"
+    ynh_systemctl --service="dnsmasq" --action="restart"
+    ynh_hide_warnings yunohost firewall allow Both 53
 fi
 
 #=================================================


### PR DESCRIPTION
## Problem

- not able to bind port 53

## Solution

- add dnsmasq conf to bind localhost
- add logic to determine assigned IP(s)
- add command to set local endpoint IP(s) for new installs; no way to change programmatically for existing instances, added preupgrade docs
- add permissions to unit file
- open 53 tcp+udp

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
