### PR TITLE
fix: disable SSO auth header injection to prevent login loop

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -77,6 +77,7 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
+    main.auth_header = false
 
     [resources.ports]
     main.default = 5380


### PR DESCRIPTION
## Problem

When a user is logged into YunoHost SSO and visits the Technitium web UI, they experience a **silent login loop**: the dashboard flashes briefly, then the browser is redirected back to the login page. No error message is shown. Private browser windows are unaffected only if the user has no active YunoHost session.

## Root cause

SSOwat's default behaviour is to inject an `Authorization: Basic <base64(yunohost_user:yunohost_password)>` header into every proxied request when `auth_header` is not explicitly set to `false`. Technitium receives this header and attempts to authenticate the YunoHost username against its own internal user database. That user does not exist in Technitium, so authentication fails and Technitium redirects to its own login page — which SSOwat intercepts again, creating the loop.

This can be observed in Technitium's application log:
```
[timestamp] [proxy_ip] [admin] User logged in.      ← Technitium login form succeeds
[timestamp] DNS Server auth config file was saved.
[timestamp] [proxy_ip] Invalid username or password for user: admin  ← SSOwat injects YNH credentials
```

## Fix

Add `main.auth_header = false` to `[resources.permissions]` in `manifest.toml`.

This is consistent with the app already declaring:
```toml
ldap = false
sso = false
```

Technitium handles its own authentication entirely; it has no YunoHost user integration and does not benefit from SSO header injection.

## Testing

Verified on a live YunoHost 12 install (Debian 13, Technitium 15.3):
- Before fix: login loop when YunoHost session is active
- After fix (manual `auth_header = false` in ssowat conf): login works correctly, Technitium serves its own login form without interference